### PR TITLE
fixing divide for dart-sass deprecation warning

### DIFF
--- a/src/util/_unit.scss
+++ b/src/util/_unit.scss
@@ -3,5 +3,5 @@
 /// @return {Number} The same number, sans unit.
 /// @access private
 @function strip-unit($num) {
-  @return $num / ($num * 0 + 1);
+  @return calc(#{$num} / (#{$num} * 0 + 1));
 }


### PR DESCRIPTION
Fixes #139 

This package is the last one throwing deprecation warnings about the divide issue, would be great to get it fixed up. It is not used anywhere in the code base, however other packages that use `motion-ui` do use the function.