### PR TITLE
Fix for Dart Sass Deprecation Warning

### DIFF
--- a/src/util/_unit.scss
+++ b/src/util/_unit.scss
@@ -2,6 +2,7 @@
 /// @param {Number} $num - Number to strip unit from.
 /// @return {Number} The same number, sans unit.
 /// @access private
+@use 'sass:math';
 @function strip-unit($num) {
-  @return $num / ($num * 0 + 1);
+  @return math.div($num, ($num * 0 + 1));
 }


### PR DESCRIPTION
DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.